### PR TITLE
Add Docker container support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+node_modules
+.git
+.gitignore
+Dockerfile
+dist
+.env
+.vscode
+.idea
+npm-debug.log*
+yarn-debug.log*
+.pnpm-debug.log*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: Build the application
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Stage 2: Run the application using a lightweight server
+FROM node:20-alpine AS runtime
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+RUN npm install -g serve
+EXPOSE 8080
+CMD ["serve", "-s", "dist", "-l", "8080"]

--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-chord-genesis
+# chord-genesis
+
+A chord progression generator built with React and Vite.
+
+## Development
+
+Install dependencies and start the dev server:
+
+```bash
+npm install
+npm run dev
+```
+
+## Docker
+
+You can build and run the application using Docker. This will compile the project and serve the static files from a lightweight container.
+
+```bash
+# Build the image
+docker build -t chord-genesis .
+
+# Run the container on port 8080
+docker run -p 8080:8080 chord-genesis
+```
+
+The site will be accessible at `http://localhost:8080`.


### PR DESCRIPTION
## Summary
- add `Dockerfile` for multi-stage build and production server
- ignore build artifacts with `.dockerignore`
- expand README with development and Docker instructions

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6882e112991c8328b1daab0ba3ef77d0